### PR TITLE
Add dependency installation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ MUSIC_BOT_URL="<YOUR-MUSIC-BOT-URL>"
 ```
 
 ## Setup
-1. Install the required Python packages:
+1. Install the required Python packages by running the helper script:
 
 ```
-pip install pyaudio vosk pvporcupine numpy pyttsx3 requests python-dotenv
+./install_dependencies.sh
 ```
+
+   The script installs everything listed in `requirements.txt` using `pip`.
 
 2. Download the Vosk English model from
    [here](https://alphacephei.com/vosk/models/vosk-model-en-us-0.22.zip) and

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Simple helper script to install Python dependencies
+set -e
+
+if ! command -v pip >/dev/null 2>&1; then
+  echo "pip is required but was not found. Please install Python and pip." >&2
+  exit 1
+fi
+
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pyaudio
+vosk
+pvporcupine
+numpy
+pyttsx3
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing Python dependencies
- add `install_dependencies.sh` script to install packages via `pip`
- update README instructions for setup

## Testing
- `python -m py_compile jarvis.py transcribe.py tts_check.py wake_word.py`
- `./install_dependencies.sh` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68451eef17948332acef95381273da0a