### PR TITLE
Handle missing MUSIC_BOT_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ VOICE_CHANNEL_ID="<TARGET-VOICE-CHANNEL-ID>"
 MUSIC_BOT_URL="<YOUR-MUSIC-BOT-URL>"
 ```
 
+If `MUSIC_BOT_URL` is omitted, Jarvis logs a warning and does not attempt to
+send music bot requests.
+
 ## Setup
 1. Install the required Python packages by running the helper script:
 

--- a/jarvis.py
+++ b/jarvis.py
@@ -143,6 +143,10 @@ def send_play_command(song_name: str, max_retries: int = 3, retry_delay: float =
     Returns:
         dict: Response from the music bot API, or None on failure
     """
+    if not music_bot_base_url:
+        logging.warning("MUSIC_BOT_URL not configured; skipping play command")
+        return None
+
     url = f"{music_bot_base_url}play"
     payload = {
         "guildId": guild_id,                # Discord Server ID where the bot operates
@@ -178,6 +182,10 @@ def send_command(command: str, max_retries: int = 3, retry_delay: float = 1.0):
     Returns:
         dict: Response from the music bot API, or None on failure
     """
+    if not music_bot_base_url:
+        logging.warning("MUSIC_BOT_URL not configured; skipping command '%s'", command)
+        return None
+
     url = f"{music_bot_base_url}{command}"
     payload = {
         "guildId": guild_id,                # Discord Server ID


### PR DESCRIPTION
## Summary
- avoid making requests when `MUSIC_BOT_URL` is unset
- document behaviour in the README

## Testing
- `python -m py_compile jarvis.py`


------
https://chatgpt.com/codex/tasks/task_e_684520fdb90c83329927ea9cb99cecc9